### PR TITLE
DEET-2069

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -41,7 +41,6 @@
                     break;
                 } else {
                   tagged = false;
-
                 }
             }
           }
@@ -57,7 +56,7 @@
     tagName: "div",
 
     html() {
-      if (!tagged) {
+      if (tagged === false) {
         return h('div', " ");
       } else {
         return h("a.btn-default.custom-button", {href: url, title:"MUG Homepage", target: "_blank"}, "MUG Homepage");

--- a/common/header.html
+++ b/common/header.html
@@ -28,6 +28,7 @@
       pluginId: "returnTags",
       didInsertElement: function() {
         this._super();
+        tagged = false;
 
         if (typeof this.topic.tags != "undefined" && this.topic.tags.length > 0) {
 
@@ -38,6 +39,9 @@
                     tagged = true;
                     url = data[i]["url"];
                     break;
+                } else {
+                  tagged = false;
+
                 }
             }
           }
@@ -53,10 +57,10 @@
     tagName: "div",
 
     html() {
-      if (tagged) {
-        return h("a.btn-default.custom-button", {href: url, title:"MUG Homepage", target: "_blank"}, "MUG Homepage");
-      } else {
+      if (!tagged) {
         return h('div', " ");
+      } else {
+        return h("a.btn-default.custom-button", {href: url, title:"MUG Homepage", target: "_blank"}, "MUG Homepage");
       }
       
     }


### PR DESCRIPTION
Adding:
```tagged = false;```
and
```
else {
                  tagged = false;
}
```

Allowed for the `var` to reset back to false whenever the user lands on a new topic, instead of inheriting the `true` value from the previous post. To verify issue is resolved, head over to staging and open a `delhi-mug` post ([like this one](https://mongodbcom-cdn.website.staging.corp.mongodb.com/community/forums/t/delhi-ncr-mug-building-react-applications-with-data-apis-scalability-with-mongodb-atlas/199607)) that shows MUG Homepage, then visit a post without `delhi-mug`. The MUG Homepage button should be gone. Only `delhi-mug` works on staging because for testing purposes I only added the one tag in the newly installed theme component. 